### PR TITLE
Support label property for Inititialize Transaction

### DIFF
--- a/lib/apis/Transaction.js
+++ b/lib/apis/Transaction.js
@@ -202,6 +202,9 @@ class Transaction extends runtime_1.BaseAPI {
             if (requestParameters.amount !== undefined) {
                 formParams['amount'] = requestParameters.amount;
             }
+            if (requestParameters.label !== undefined) {
+                formParams['label'] = requestParameters.label;
+            }
             if (requestParameters.currency !== undefined) {
                 formParams['currency'] = requestParameters.currency;
             }

--- a/lib/types/apis/Transaction.d.ts
+++ b/lib/types/apis/Transaction.d.ts
@@ -45,6 +45,7 @@ export interface FetchRequest {
 export interface InitializeRequest {
     email: string;
     amount: number;
+    label?: string;
     currency?: string;
     reference?: string;
     callback_url?: string;

--- a/src/apis/Transaction.ts
+++ b/src/apis/Transaction.ts
@@ -58,6 +58,7 @@ export interface FetchRequest {
 export interface InitializeRequest {
     email: string;
     amount: number;
+    label?: string;
     currency?: string;
     reference?: string;
     callback_url?: string;
@@ -107,7 +108,7 @@ export interface VerifyRequest {
 }
 
 /**
- * 
+ *
  */
 export class Transaction extends BaseAPI {
 
@@ -179,7 +180,7 @@ export class Transaction extends BaseAPI {
             query: queryParameters,
             body: formParams,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -220,7 +221,7 @@ export class Transaction extends BaseAPI {
             query: queryParameters,
             body: formParams,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -252,7 +253,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -271,7 +272,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -291,7 +292,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -316,6 +317,10 @@ export class Transaction extends BaseAPI {
 
         if (requestParameters.amount !== undefined) {
             formParams['amount'] = requestParameters.amount;
+        }
+
+        if (requestParameters.label !== undefined) {
+            formParams['label'] = requestParameters.label;
         }
 
         if (requestParameters.currency !== undefined) {
@@ -369,7 +374,7 @@ export class Transaction extends BaseAPI {
             query: queryParameters,
             body: formParams,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -402,7 +407,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -457,7 +462,7 @@ export class Transaction extends BaseAPI {
             query: queryParameters,
             body: formParams,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -476,7 +481,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -496,7 +501,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -529,7 +534,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 
@@ -549,7 +554,7 @@ export class Transaction extends BaseAPI {
             method: 'GET',
             query: queryParameters,
         });
-        
+
         return ResponseFromJSON(response);
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## What issue does this change solve?
When initializing a transaction, the api endpoint supports sending label but it is not exposed via this SDK. 

# Additional context
This is useful for people like myself who want to initialize transaction on the server, and complete it with Paystack Pop, but want the label to appear and not the email on the pop up. Since the email is not guaranteed to make sense to the customer if they do not have one captured and the email shown was generated.